### PR TITLE
Fix missing annotations NoAdminRequired for normal user

### DIFF
--- a/lib/Controller/ZimbraAPIController.php
+++ b/lib/Controller/ZimbraAPIController.php
@@ -85,6 +85,8 @@ class ZimbraAPIController extends Controller {
 	}
 
 	/**
+	 * @NoAdminRequired
+	 *
 	 * @return DataResponse
 	 */
 	public function getContacts() {
@@ -101,6 +103,8 @@ class ZimbraAPIController extends Controller {
 	}
 
 	/**
+	 * @NoAdminRequired
+	 *
 	 * @return DataResponse
 	 */
 	public function getUnreadEmails(int $offset = 0, int $limit = 10) {
@@ -117,6 +121,8 @@ class ZimbraAPIController extends Controller {
 	}
 
 	/**
+	 * @NoAdminRequired
+	 *
 	 * @return DataResponse
 	 */
 	public function getUpcomingEvents() {


### PR DESCRIPTION
Hi, Widgets don't works with normal user because nextcloud ask for an admin role.